### PR TITLE
 Add Wagtail signal handlers to rebuild on publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ manage.py build` from the root of the repository to bake the site out to static
 HTML. That makes it much easier and lighter to host, improves scalability, and
 helps with security too.
 
+The build management command is also wired into the `page_published` and
+`page_unpublished` Wagtail signals so that when a page is published or
+unpublished the site will automatically re-bake. This will make it easier for
+the static site to mirror the *published* portion of the dynamically served
+site stored in the database. Note that as of now, the site is just re-baked,
+not re-deployed; that will come once the site is live and it actually has
+somewhere to deploy.
+
 
 [1]: https://wagtail.io/
 [2]: https://github.com/wagtail/wagtail-bakery

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,1 @@
+from . import wagtail_signals  # Import this so it's executed at start-up

--- a/core/wagtail_signals.py
+++ b/core/wagtail_signals.py
@@ -1,0 +1,17 @@
+from django.core.management import call_command
+from wagtail.core.signals import page_published, page_unpublished
+
+
+def bake_site(sender, **kwargs):
+    '''
+    This helper function will trigger a re-build of the site automatically when
+    a page is published or unpublished so that the static HTML being served
+    gets synced with the changes published to the dynamic app.
+    '''
+    # TODO: either extend this function or call a different command so that we
+    #       re-build and also re-deploy here.
+    call_command('build')
+
+
+page_published.connect(bake_site)
+page_unpublished.connect(bake_site)


### PR DESCRIPTION
Add Wagtail signal handlers (defined in `core/wagtail_signals.py`) to
automatically re-bake the site when a page is published or unpublished.
This will allow the static site to automatically mirror the *published*
part of the site in the database.